### PR TITLE
Allow for a better handling of low resolution screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Warhamer Fantasy Role-Play 4th Ed. (FoundryVTT)
 
-Current Version: 1.2.1 - Fix Armour qualities/flaws not being translated, shields not reducing AP, chat cards not being editable
+Current Version: 1.2.2 - Fix Armour qualities/flaws not being translated, shields not reducing AP, chat cards not being editable
 
 Compatibility: Foundry VTT 0.5.4
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Warhamer Fantasy Role-Play 4th Ed. (FoundryVTT)
 
-Current Version: 1.2.2 - Fix Armour qualities/flaws not being translated, shields not reducing AP, chat cards not being editable
+Current Version: 1.2.3 - Fix Armour qualities/flaws not being translated, shields not reducing AP, chat cards not being editable
 
 Compatibility: Foundry VTT 0.5.4
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Warhamer Fantasy Role-Play 4th Ed. (FoundryVTT)
 
-Current Version: 1.2.0
+Current Version: 1.2.1 - Fix Armour qualities/flaws not being translated, shields not reducing AP, chat cards not being editable
 
 Compatibility: Foundry VTT 0.5.4
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Warhamer Fantasy Role-Play 4th Ed. (FoundryVTT)
 
-Current Version: 1.2
+Current Version: 1.2.0
 
 Compatibility: Foundry VTT 0.5.4
 

--- a/css/wfrp4e.css
+++ b/css/wfrp4e.css
@@ -3387,17 +3387,17 @@
     background: none;
     overflow-y: hidden;
     border: none;
-    margin: 3px 26px 65px 8px;
     padding: 0px 0px 0px 0px;
+    margin: 3px 26px 0px 8px;
   }
   .app.window-app.sheet.wfrp4e.actor.character-sheet .window-content form {
+    margin: 45px 35px 0px 35px;
     display: inline-block;
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: normal;
     overflow-y: hidden;
     overflow-x: hidden;
-    margin: 45px 35px;
     padding: 0px;
     /* box-shadow: var(--debug-box-shadow-red); */
   }

--- a/lang/en.json
+++ b/lang/en.json
@@ -687,6 +687,11 @@
     "PROPERTY.Lightweight": "Lightweight",
     "PROPERTY.Practical": "Practical",
 
+    "PROPERTY.Flexible" : "Flexible",
+    "PROPERTY.Impenetrable" : "Impenetrable",
+    "PROPERTY.Partial" : "Partial",
+    "PROPERTY.Weakpoints" : "Weakpoints",
+
     "WFRP4E.BPandEng" : "Blackpowder and Engineering",
     "WFRP4E.Bow" : "Bow",
     "WFRP4E.Crossbow" : "Crossbow",

--- a/scripts/actor/actor-wfrp4e.js
+++ b/scripts/actor/actor-wfrp4e.js
@@ -184,7 +184,7 @@ class ActorWfrp4e extends Actor {
    */
   setupCharacteristic(characteristicId, options = {}) {
     let char = this.data.data.characteristics[characteristicId];
-    let title = char.label + " " + game.i18n.localize("Test");
+    let title = game.i18n.localize(char.label) + " " + game.i18n.localize("Test");
 
     let testData = {
       target : char.value,
@@ -2804,7 +2804,7 @@ class ActorWfrp4e extends Actor {
     for(let ch in actorData.data.characteristics)
     { 
       // If formula includes characteristic name
-      while (formula.includes(actorData.data.characteristics[ch].label.toLowerCase()))
+      while (formula.includes(game.i18n.localize(actorData.data.characteristics[ch].label).toLowerCase()))
       {
         // Determine if it's looking for the bonus or the value
         if (formula.includes('bonus'))

--- a/scripts/actor/actor-wfrp4e.js
+++ b/scripts/actor/actor-wfrp4e.js
@@ -3018,8 +3018,8 @@ class ActorWfrp4e extends Actor {
       let shieldAP = 0;
       if (opposeData.defenderTestResult.weapon)
       {
-        if (opposeData.defenderTestResult.weapon.properties.qualities.find(q => q.includes("PROPERTY.Shield")))
-          shieldAP = Number(opposeData.defenderTestResult.weapon.properties.qualities.find(q => q.includes("PROPERTY.Shield")).split(" ")[1])
+        if (opposeData.defenderTestResult.weapon.properties.qualities.find(q => q.toLowerCase().includes(game.i18n.localize("PROPERTY.Shield").toLowerCase())))
+          shieldAP = Number(opposeData.defenderTestResult.weapon.properties.qualities.find(q => q.toLowerCase().includes(game.i18n.localize("PROPERTY.Shield").toLowerCase())).split(" ")[1]);
       }
 
       if (shieldAP)

--- a/scripts/actor/actor-wfrp4e.js
+++ b/scripts/actor/actor-wfrp4e.js
@@ -1438,18 +1438,11 @@ class ActorWfrp4e extends Actor {
       // Different update process based on if token or not.
       if (this.isToken && this.token.data.height != tokenSize) // Actor checking if its prototype token is correct
       {
-        this.token.update(this.token.scene._id, 
-          {
-          "height" : tokenSize,
-          "width" : tokenSize
-          })
+        this.token.update({"height" : tokenSize,"width" : tokenSize})
       }
       else if (preparedData.token.height != tokenSize) // Token checking whether its size is correct
       {
-        this.update({
-        "token.height" : tokenSize,
-        "token.width" : tokenSize
-        })
+        this.update({"token.height" : tokenSize,"token.width" : tokenSize})
       }
     }
     catch { }

--- a/scripts/dice-wfrp4e.js
+++ b/scripts/dice-wfrp4e.js
@@ -773,7 +773,7 @@ class DiceWFRP
         {
           content: html,
           ["flags.data"]: chatOptions["flags.data"]
-        }, true).then(newMsg =>
+        }).then(newMsg =>
         {
           ui.chat.updateMessage(newMsg);
         });

--- a/system.json
+++ b/system.json
@@ -177,6 +177,7 @@
   "primaryTokenAttribute": "status.wounds",
   "secondaryTokenAttribute": "status.advantage",
   "minimumCoreVersion" : "0.5.4",
+  "compatibleCoreVersion" : "0.5.5",
   "templateVersion":2,
   "socket": true,
   "manifest" :  "https://raw.githubusercontent.com/CatoThe1stElder/WFRP-4th-Edition-FoundryVTT/stable/system.json",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "wfrp4e",
   "title": "Warhammer Fantasy Roleplay 4th Edition",
   "description": "A comprehensive system for running grim and perilious games of Warhammer Fantasy Roleplay in the Foundry VTT environment.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "CatoThe1stElder, Moo Man",
   "scripts": [
     "./scripts/config-wfrp4e.js",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "wfrp4e",
   "title": "Warhammer Fantasy Roleplay 4th Edition",
   "description": "A comprehensive system for running grim and perilious games of Warhammer Fantasy Roleplay in the Foundry VTT environment.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": "CatoThe1stElder, Moo Man",
   "scripts": [
     "./scripts/config-wfrp4e.js",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "wfrp4e",
   "title": "Warhammer Fantasy Roleplay 4th Edition",
   "description": "A comprehensive system for running grim and perilious games of Warhammer Fantasy Roleplay in the Foundry VTT environment.",
-  "version": "1.2",
+  "version": "1.2.0",
   "author": "CatoThe1stElder, Moo Man",
   "scripts": [
     "./scripts/config-wfrp4e.js",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "wfrp4e",
   "title": "Warhammer Fantasy Roleplay 4th Edition",
   "description": "A comprehensive system for running grim and perilious games of Warhammer Fantasy Roleplay in the Foundry VTT environment.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "CatoThe1stElder, Moo Man",
   "scripts": [
     "./scripts/config-wfrp4e.js",


### PR DESCRIPTION
I haven't found any drawbacks to lower the margin-bottom to 0px on every screens and browsers I tested.

It fix the character sheets for window between 630px height and 730px height to now be able to see the character sheet instead of being cut by the footer.

It can happens easily on some laptop with the bookmark bar on Chrome.

Should probably need to be reviewed by  @CatoThe1stElder to be sure.