### PR TITLE
[Dev backend] Add a /help command

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -87,7 +87,7 @@
     "SHEET.CharAbbrev": "Char.",
     "SHEET.AdvAbbrev": "Adv.",
     "SHEET.BonusChar": "Bonus of selected characteristic is added to Rating",
-    
+
 
     "ACTOR.BasicSkillsTitle" : "Add Basic Skills",
     "ACTOR.BasicSkillsPrompt": "Add Basic Skills?",
@@ -292,7 +292,7 @@
     "Prayer" : "Prayer",
     "Trait" : "Trait",
     "Protects" : "Protects",
-    
+
     "BROWSER.ItemCategories" : "Item Categories",
     "BROWSER.IncludeWorld" : "Include World Items?",
     "BROWSER.FilterOptions" : "Filter Options",
@@ -352,6 +352,34 @@
     "CHAT.ContextualMenu" : "A contextual menu could be available on this card (right click)",
     "CHAT.EditTest" : "Edit Test",
     "CHAT.OpposedTest" : "Opposed Test",
+    "CHAT.CommandLine.Help.Commands" : "Tables,Conditions,CharacterGeneration,NameGeneration,AvailabilityTest,Pay",
+    "CHAT.CommandLine.Help.Label.Command" : "Command",
+    "CHAT.CommandLine.Help.Label.Example": "Example",
+    "CHAT.CommandLine.Help.Label.Note": "Note",
+    "CHAT.CommandLine.Help.Tables.Title" : "Tables",
+    "CHAT.CommandLine.Help.Tables.Usage.Command" : "/table <table-name> <column> <modifier>",
+    "CHAT.CommandLine.Help.Tables.Usage.Example" : "/table critarm +20 /table career human",
+    "CHAT.CommandLine.Help.Tables.Usage.Note" : "/table <anything-unrecognized> will pull up the table help menu",
+    "CHAT.CommandLine.Help.Conditions.Title" : "Conditions",
+    "CHAT.CommandLine.Help.Conditions.Usage.Command" : "/cond <condition-name>",
+    "CHAT.CommandLine.Help.Conditions.Usage.Example" : "/cond ablaze /table unconsc",
+    "CHAT.CommandLine.Help.Conditions.Usage.Note" : "will match the closest spelling condition and display it (eg. /cond abl == /cond ablaze)",
+    "CHAT.CommandLine.Help.CharacterGeneration.Title" : "Character Generation",
+    "CHAT.CommandLine.Help.CharacterGeneration.Usage.Command" : "/char",
+    "CHAT.CommandLine.Help.CharacterGeneration.Usage.Example" : "/char",
+    "CHAT.CommandLine.Help.CharacterGeneration.Usage.Note" : "Begins character generation",
+    "CHAT.CommandLine.Help.NameGeneration.Title" : "Name Generation",
+    "CHAT.CommandLine.Help.NameGeneration.Usage.Command" : "/name",
+    "CHAT.CommandLine.Help.NameGeneration.Usage.Example" : "/name dwarf /name helf male /name welf female",
+    "CHAT.CommandLine.Help.NameGeneration.Usage.Note" : "Generates a name in chat (Also accessible by clicking the <Name> label on a an NPC or creature sheet)",
+    "CHAT.CommandLine.Help.AvailabilityTest.Title" : "Availability Test",
+    "CHAT.CommandLine.Help.AvailabilityTest.Usage.Command" : "/avail",
+    "CHAT.CommandLine.Help.AvailabilityTest.Usage.Example" : "/avail town common /avail city exotic",
+    "CHAT.CommandLine.Help.AvailabilityTest.Usage.Note" : "rolls an availability test to determine the availability and the stock of an item.",
+    "CHAT.CommandLine.Help.Pay.Title" : "Pay",
+    "CHAT.CommandLine.Help.Pay.Usage.Command" : "/pay",
+    "CHAT.CommandLine.Help.Pay.Usage.Example" : "/pay 3gc2bp /pay 10bp450ss",
+    "CHAT.CommandLine.Help.Pay.Usage.Note" : "If this command is sent by the GM, it will create instead a chat card where players are offered to pay for the amount entered by the GM.",
 
     "Error.SpeciesSkills" : "Could not add skills for species",
     "Error.SpeciesTalents" : "Could not add talents for species",
@@ -593,7 +621,7 @@
 	"CHAR.Int": "Intelligence",
 	"CHAR.WP": "Willpower",
     "CHAR.Fel": "Fellowship",
-    
+
     "CHARAbbrev.WS": "WS",
 	"CHARAbbrev.BS": "BS",
 	"CHARAbbrev.S": "S",
@@ -604,7 +632,7 @@
 	"CHARAbbrev.Int": "Int",
 	"CHARAbbrev.WP": "WP",
     "CHARAbbrev.Fel": "Fel",
-    
+
 
     "CHARBonus.WS": "Weapon Skill Bonus",
 	"CHARBonus.BS": "Ballistic Skill Bonus",

--- a/lang/en.json
+++ b/lang/en.json
@@ -362,7 +362,7 @@
     "CHAT.CommandLine.Help.Tables.Usage.Note" : "/table <anything-unrecognized> will pull up the table help menu",
     "CHAT.CommandLine.Help.Conditions.Title" : "Conditions",
     "CHAT.CommandLine.Help.Conditions.Usage.Command" : "/cond <condition-name>",
-    "CHAT.CommandLine.Help.Conditions.Usage.Example" : "/cond ablaze /table unconsc",
+    "CHAT.CommandLine.Help.Conditions.Usage.Example" : "/cond ablaze /cond unconsc",
     "CHAT.CommandLine.Help.Conditions.Usage.Note" : "will match the closest spelling condition and display it (eg. /cond abl == /cond ablaze)",
     "CHAT.CommandLine.Help.CharacterGeneration.Title" : "Character Generation",
     "CHAT.CommandLine.Help.CharacterGeneration.Usage.Command" : "/char",

--- a/scripts/hooks/chatMessage.js
+++ b/scripts/hooks/chatMessage.js
@@ -6,72 +6,68 @@
  * /name  - Generate a name
  * /avail - Start an item availability test
  * /pay - Player: Remove money from character. GM: Start a payment request
+ * /help - display a help message on all the commands above
  */
 Hooks.on("chatMessage", (html, content, msg) => {
     // Setup new message's visibility
     let rollMode = game.settings.get("core", "rollMode");
-    if ( ["gmroll", "blindroll"].includes(rollMode) ) msg["whisper"] = ChatMessage.getWhisperIDs("GM");
-    if ( rollMode === "blindroll" ) msg["blind"] = true;
+    if (["gmroll", "blindroll"].includes(rollMode)) msg["whisper"] = ChatMessage.getWhisperIDs("GM");
+    if (rollMode === "blindroll") msg["blind"] = true;
     msg["type"] = 0;
 
     // Split input into arguments
-    let command = content.split(" ").map(function(item) {
-      return item.trim();
-    })
-    // Roll on a table
-    if (command[0] == "/table")
-    {
-      // If no argument, display help menu
-      if (command.length == 1)
-        msg.content = WFRP_Tables.formatChatRoll("menu")
-      else
-      {
-        // [0]: /table [1]: <table-name> [2]: argument1 [3]: argument2
-        let modifier, column // Possible arguments
-        // If argument 1 is a number use it as the modifier
-        if (!isNaN(command[2]))  
-        {
-          modifier = parseInt(command[2]);
-          column = command[3]
+    let command = content.split(" ").map(function (item) {
+        return item.trim();
+    });
+
+// Roll on a table
+    if (command[0] === "/table") {
+        // If no argument, display help menu
+        if (command.length === 1)
+            msg.content = WFRP_Tables.formatChatRoll("menu");
+        else {
+            // [0]: /table [1]: <table-name> [2]: argument1 [3]: argument2
+            let modifier, column; // Possible arguments
+            // If argument 1 is a number use it as the modifier
+            if (!isNaN(command[2])) {
+                modifier = parseInt(command[2]);
+                column = command[3]
+            } else // if argument 1 is not a number, use it as column
+            {
+                modifier = parseInt(command[3]),
+                    column = command[2]
+            }
+            // Call tables class to roll and return html
+            msg.content = WFRP_Tables.formatChatRoll(command[1], {modifier: modifier}, column)
         }
-        else // if argument 1 is not a number, use it as column
-        {
-          modifier = parseInt(command[3]),
-          column = command[2]
-        }
-        // Call tables class to roll and return html
-        msg.content = WFRP_Tables.formatChatRoll(command[1], {modifier : modifier}, column)
-      }
-      // Create message and return false to not display user input of `/table`
-      if (msg)
-        ChatMessage.create(msg);
-      return false;
+        // Create message and return false to not display user input of `/table`
+        if (msg)
+            ChatMessage.create(msg);
+        return false;
     }
-    
+
     // Lookup a condition
-    else if (command[0] == "/cond")
-    {
-      // Only one argument possible [1]: condition to lookup
-      let conditionInput = command[1].toLowerCase();
-      // Don't require spelling, match the closest condition to the input
-      let closest = WFRP_Utility.matchClosest(WFRP4E.conditions, conditionInput)
-      let description = WFRP4E.conditionDescriptions[closest];
-      let name = WFRP4E.conditions[closest];
-  
-      // Create message and return false to not display user input of `/cond`
-      msg.content = `<b>${name}</b><br>${description}`
-      ChatMessage.create(msg);
-      return false;
+    else if (command[0] === "/cond") {
+        // Only one argument possible [1]: condition to lookup
+        let conditionInput = command[1].toLowerCase();
+        // Don't require spelling, match the closest condition to the input
+        let closest = WFRP_Utility.matchClosest(WFRP4E.conditions, conditionInput);
+        let description = WFRP4E.conditionDescriptions[closest];
+        let name = WFRP4E.conditions[closest];
+
+        // Create message and return false to not display user input of `/cond`
+        msg.content = `<b>${name}</b><br>${description}`;
+        ChatMessage.create(msg);
+        return false;
     }
     // Character generation
-    else if (command[0] == "/char")
-    {
-      // Begin character generation, return false to not display user input of `/char`
-      GeneratorWfrp4e.speciesStage()
-      return false;
+    else if (command[0] === "/char") {
+        // Begin character generation, return false to not display user input of `/char`
+        GeneratorWfrp4e.speciesStage();
+        return false;
     }
     // Name generation
-    else if (command[0] == "/name")
+    else if (command[0] === "/name")
     {
       // Possible arguments - [2]: gender, [1]: species
       let gender = (command[2] || "").toLowerCase()
@@ -82,10 +78,10 @@ Hooks.on("chatMessage", (html, content, msg) => {
       return false;
     }
     // Availability test
-    else if (command[0] == "/avail")
+    else if (command[0] === "/avail")
     {
       let modifier = 0;
-      // Possible arguments - [1]: settlement size, [2]: item rarity [3*]: modifier 
+      // Possible arguments - [1]: settlement size, [2]: item rarity [3*]: modifier
 
       let settlement = (command[1] || "").toLowerCase();
       let rarity = (command[2] || "").toLowerCase();
@@ -93,13 +89,13 @@ Hooks.on("chatMessage", (html, content, msg) => {
       {
         modifier = command[3];
       }
-      
+
       // Call generator class to start the test, create message, send to chat, return false to not display user input of `/avail`
       MarketWfrp4e.testForAvailability({settlement, rarity, modifier});
       return false;
     }
     // Pay command
-    else if (command[0] == "/pay")
+    else if (command[0] === "/pay")
     {
       //The parameter is a string that will be exploded by a regular expression
       let param  = content.substring(5);
@@ -107,7 +103,7 @@ Hooks.on("chatMessage", (html, content, msg) => {
       if(!game.user.isGM)
       {
         let actor = WFRP_Utility.getSpeaker(msg.speaker);
-        let money = duplicate(actor.data.items.filter(i => i.type == "money"));
+        let money = duplicate(actor.data.items.filter(i => i.type === "money"));
         money = MarketWfrp4e.payCommand(param,money);
         if(money)
           actor.updateEmbeddedEntity("OwnedItem", money);
@@ -116,4 +112,27 @@ Hooks.on("chatMessage", (html, content, msg) => {
         MarketWfrp4e.generatePayCard(param);
       return false;
     }
-  });
+    //Help command
+    else if (command[0] === "/help")
+    {
+        let rawCommands=game.i18n.localize("CHAT.CommandLine.Help.Commands");
+
+        let commandElements = rawCommands.split(",").map(function (item) {
+            return {
+                title: game.i18n.localize(`CHAT.CommandLine.Help.${item}.Title`),
+                command: game.i18n.localize(`CHAT.CommandLine.Help.${item}.Usage.Command`),
+                commandLabel: game.i18n.localize(`CHAT.CommandLine.Help.Label.Command`),
+                example: game.i18n.localize(`CHAT.CommandLine.Help.${item}.Usage.Example`),
+                exampleLabel: game.i18n.localize(`CHAT.CommandLine.Help.Label.Example`),
+                note: game.i18n.localize(`CHAT.CommandLine.Help.${item}.Usage.Note`),
+                noteLabel: game.i18n.localize(`CHAT.CommandLine.Help.Label.Note`),
+            };
+        });
+
+        renderTemplate("systems/wfrp4e/templates/chat/chat-help-command.html", {commands: commandElements}).then(html => {
+            let chatData = WFRP_Utility.chatDataSetup(html);
+            ChatMessage.create(chatData);
+        });
+        return false;
+    }
+});

--- a/scripts/hooks/init.js
+++ b/scripts/hooks/init.js
@@ -343,6 +343,7 @@ Hooks.once("init", () => {
       "systems/wfrp4e/templates/actors/creature-main.html",
       "systems/wfrp4e/templates/chat/dialog-constant.html",
       "systems/wfrp4e/templates/chat/test-card.html",
+      "systems/wfrp4e/templates/chat/chat-command-display-info.html",
       "systems/wfrp4e/templates/items/item-header.html",
       "systems/wfrp4e/templates/items/item-description.html",
     ]);

--- a/templates/chat/chat-command-display-info.html
+++ b/templates/chat/chat-command-display-info.html
@@ -1,0 +1,6 @@
+<div>
+    <h2>{{this.title}}</h2>
+    <p><strong>{{commandLabel}}:</strong> <code>{{this.command}}</code></p>
+    <p><strong>{{exampleLabel}}:</strong> {{this.example}}</p>
+    <p><strong>{{noteLabel}}:</strong> {{this.note}}</p>
+</div>

--- a/templates/chat/chat-help-command.html
+++ b/templates/chat/chat-help-command.html
@@ -1,0 +1,6 @@
+<div class="wfrp4e chat-card" data-actor-id="{{actorId}}" data-hide={{hideData}}>
+    {{#each commands}}
+    {{> systems/wfrp4e/templates/chat/chat-command-display-info.html}}
+    {{/each}}
+
+</div>


### PR DESCRIPTION
In the chat box, add a /help command to display helps about the commands availables.

Please find below an example of the result

<img width="346" alt="Capture d’écran 2020-04-26 à 19 55 47" src="https://user-images.githubusercontent.com/5511927/80315605-f88f4700-87f8-11ea-9d69-a8d0644093b9.png">

This PR uses i18n and template to  do the job.
