### PR TITLE
Fix a bug in a non combat opposed roll

### DIFF
--- a/scripts/opposed-wfrp4e.js
+++ b/scripts/opposed-wfrp4e.js
@@ -206,10 +206,11 @@ class OpposedWFRP
       }
       else // Defender won
       {
-        if(opposeResult.attackerTestResult.weapon.data.weaponGroup.value == game.i18n.localize("SPEC.Bow") 
-        || opposeResult.attackerTestResult.weapon.data.weaponGroup.value == game.i18n.localize("SPEC.Crossbow")
-        || opposeResult.attackerTestResult.weapon.data.weaponGroup.value == game.i18n.localize("SPEC.Blackpowder")
-        || opposeResult.attackerTestResult.weapon.data.weaponGroup.value == game.i18n.localize("SPEC.Engineering"))
+        if (typeof opposeResult.attackerTestResult.weapon !== "undefined"
+            && (opposeResult.attackerTestResult.weapon.data.weaponGroup.value == game.i18n.localize("SPEC.Bow")
+            || opposeResult.attackerTestResult.weapon.data.weaponGroup.value == game.i18n.localize("SPEC.Crossbow")
+            || opposeResult.attackerTestResult.weapon.data.weaponGroup.value == game.i18n.localize("SPEC.Blackpowder")
+            || opposeResult.attackerTestResult.weapon.data.weaponGroup.value == game.i18n.localize("SPEC.Engineering")))
           WFRP_Utility.PlayContextAudio(opposeResult.attackerTestResult.weapon, {"type": "weapon", "equip": "miss"})
         opposeResult.winner = "defender"
         differenceSL = defenderSL - attackerSL; 


### PR DESCRIPTION
FIX
when an attacker loose against a defender in a non combat action, there is no weapon data so it fires an exception.