### PR TITLE
Remove the roll from the preData to fix fortune/DS reroll

### DIFF
--- a/scripts/actor/actor-wfrp4e.js
+++ b/scripts/actor/actor-wfrp4e.js
@@ -3400,6 +3400,7 @@ class ActorWfrp4e extends Actor {
         {
           cardOptions.startMessagesList = data.startMessagesList;
         }
+        delete data.preData.roll;
         ActorWfrp4e[data.postData.postFunction](data.preData,cardOptions);
         //We also set fortuneUsedAddSL to force the player to use it on the new roll
         message.update({
@@ -3459,6 +3460,7 @@ class ActorWfrp4e extends Actor {
     {
       cardOptions.startMessagesList = data.startMessagesList;
     }
+    delete message.data.flags.data.preData.roll;
     ActorWfrp4e[message.data.flags.data.postData.postFunction](message.data.flags.data.preData,cardOptions);
   }
 


### PR DESCRIPTION
It was added because of the change made in the roll system for DiceSoNice